### PR TITLE
Bump version to v7.16.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,21 @@
-FROM adoptopenjdk/openjdk16:alpine-slim
+FROM eclipse-temurin:17-jdk
 
 ENV LANG=C.UTF-8 \
-    JAVA_HOME=/opt/java/openjdk \
+    ES_JAVA_HOME=/opt/java/openjdk \
     PATH=${PATH}:/opt/java/openjdk/bin \
     LANG=C.UTF-8 \
-    ES_VERSION="7.11.2"
+    ES_VERSION="7.16.1"
 
 RUN sed -i s/#networkaddress.cache.ttl=-1/networkaddress.cache.ttl=10/ $JAVA_HOME/conf/security/java.security
 
 RUN \
-    apk --no-cache add bash && \
     mkdir -p /opt/elasticsearch && \
     cd /opt/elasticsearch && \
-    wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ES_VERSION}-linux-x86_64.tar.gz && \
+    curl -O https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ES_VERSION}-linux-x86_64.tar.gz && \
     tar -zxvf elasticsearch-${ES_VERSION}-linux-x86_64.tar.gz --strip 1 && \
     rm elasticsearch-${ES_VERSION}-linux-x86_64.tar.gz && \
-    addgroup -S -g 82 elasticsearch && \
-    adduser -S -D -H -u 82 elasticsearch -G elasticsearch && \
+    addgroup --system --gid 82 elasticsearch && \
+    adduser --system --disabled-password --no-create-home --uid 82 elasticsearch --ingroup elasticsearch && \
     chown -R elasticsearch:elasticsearch /opt/elasticsearch
 
 USER elasticsearch


### PR DESCRIPTION
- update version to [v7.16.1](https://www.elastic.co/guide/en/elasticsearch/reference/7.16/release-notes-7.16.1.html)
- switch to eclipse-temurin for the base image - adoptopenjdk is no longer maintained

---

`ES_JAVA_HOME` adjustment deals with:
```
warning: usage of JAVA_HOME is deprecated, use ES_JAVA_HOME
```

Also note that `JAVA_HOME` is set by default anyway.

---

Ditching alpine based images as ES is now looking to run executables dynamically linked to glibc:

```
org.elasticsearch.bootstrap.StartupException: org.elasticsearch.bootstrap.BootstrapException: java.io.IOException: Cannot run program "/opt/elasticsearch/modules/x-pack-ml/platform/linux-x86_64/bin/controller": error=2, No such file or directory
```
```
/opt/elasticsearch/bin $ ls -la /opt/elasticsearch/modules/x-pack-ml/platform/linux-x86_64/bin/controller 
-rwxr-xr-x    1 elastics elastics    149832 Dec 11 00:31 /opt/elasticsearch/modules/x-pack-ml/platform/linux-x86_64/bin/controller
/opt/elasticsearch/bin $ /opt/elasticsearch/modules/x-pack-ml/platform/linux-x86_64/bin/controller 
sh: /opt/elasticsearch/modules/x-pack-ml/platform/linux-x86_64/bin/controller: not found
/opt/elasticsearch/bin # file /opt/elasticsearch/modules/x-pack-ml/platform/linux-x86_64/bin/controller
/opt/elasticsearch/modules/x-pack-ml/platform/linux-x86_64/bin/controller: ELF 64-bit LSB pie executable, x86-64, version 1 (GNU/Linux), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, for GNU/Linux 2.6.18, stripped
/opt/elasticsearch/bin # stat /lib64/ld-linux-x86-64.so.2
stat: can't stat '/lib64/ld-linux-x86-64.so.2': No such file or directory
```

Basically it wants glibc as far as I can tell. Explored using `libc6-compat` but this is reportedly only a lightweight compatibility layer, and whilst I could get things started some not so friendly looking warnings were logged out. Beyond all of that [ES does not officially support Alpine](https://www.elastic.co/support/matrix).. so all in all switching to an Ubuntu based image seems worth it. It comes with a certain cost to image size.

Off the back of that change:
- switched to curl instead of wget - curl is available by default, wget is not, so apt install would be required
- adjusting adduser/addgroup flags