### PR TITLE
Update to v7.16.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ENV LANG=C.UTF-8 \
     ES_JAVA_HOME=/opt/java/openjdk \
     PATH=${PATH}:/opt/java/openjdk/bin \
     LANG=C.UTF-8 \
-    ES_VERSION="7.16.2"
+    ES_VERSION="7.16.3"
 
 RUN sed -i s/#networkaddress.cache.ttl=-1/networkaddress.cache.ttl=10/ $JAVA_HOME/conf/security/java.security
 


### PR DESCRIPTION
- https://www.elastic.co/guide/en/elasticsearch/reference/current/release-notes-7.16.3.html

Most noteworthy change is:

>  Upgrade to log4j 2.17.1

2.17.0 is reportedly vulnerable to CVE-2021-44832 (this is different to the original log4j vulnerability CVE-2021-44228)
