### PR TITLE
Support es 8.8.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ENV LANG=C.UTF-8 \
     ES_JAVA_HOME=/opt/java/openjdk \
     PATH=${PATH}:/opt/java/openjdk/bin \
     LANG=C.UTF-8 \
-    ES_VERSION="7.17.7"
+    ES_VERSION="8.8.1"
 
 RUN sed -i s/#networkaddress.cache.ttl=-1/networkaddress.cache.ttl=10/ $JAVA_HOME/conf/security/java.security
 
@@ -22,7 +22,7 @@ USER elasticsearch
 WORKDIR /opt/elasticsearch/bin
 
 RUN \
-    ./elasticsearch-plugin install -b https://github.com/vvanholl/elasticsearch-prometheus-exporter/releases/download/${ES_VERSION}.0/prometheus-exporter-${ES_VERSION}.0.zip && \
+    ./elasticsearch-plugin install -b https://github.com/andyp-uw/elasticsearch-prometheus-exporter/releases/download/${ES_VERSION}.0/prometheus-exporter-${ES_VERSION}.0.zip && \
     ./elasticsearch-plugin install -b repository-s3
 
 CMD ["./elasticsearch"]


### PR DESCRIPTION
No build of the `elasticsearch-prometheus-exporter` exists for version 8.8.1 so I have [forked the original repo](https://github.com/andyp-uw/elasticsearch-prometheus-exporter) and have fixed, built and released a version for 8.8.1. 

I've tested this in `dev-merit` and all seems to be ok. 

The `repository-s3` plugin is included in version 8.8.1 by default so there's no need to install it.

I've actually made use of the [elasticsearch-exporter](quay.io/prometheuscommunity/elasticsearch-exporter:latest) from the `prometheuscommunity` which runs as a separate deployment but the option to use the original `elasticsearch-prometheus-exporter` is still there for people that want to do that. 

@GKimbles - Should I move my fork of `elasticsearch-prometheus-exporter` to the `utilitywarehouse` org? Or `uw-labs`?

Thanks 🙇 